### PR TITLE
Scanstate syantax adjustments and Custom XML Features.

### DIFF
--- a/Invoke-USMTGUI.ps1
+++ b/Invoke-USMTGUI.ps1
@@ -69,6 +69,10 @@ begin {
         $Script:USMTPath = "$PSScriptRoot\USMT\x86"
     }
 
+	#Define Encryption options for the mig file.
+	#Set this to $True or $False
+	$UseEncryption = $True
+	$EncryptionString = 'P@ssw0rd!'
 
     # Users to additionially send every migration result to
     $Script:DefaultEmailEnabled = $false
@@ -671,6 +675,15 @@ $WallpapersXML
                 }
             }
 
+            # Clear encryption syntax in case it's already defined.
+            $EncryptionSnytax = ""
+            #Determine if Encryption has been requested
+			if ($UseEncryption -eq $True){
+				#Set the syntax for the encryption
+				$EncryptionKey = """$EncryptionString"""
+				$EncryptionSnytax = "/encrypt /key:$EncryptionKey"
+			}
+			
             #Determine if Custom XMLS were defined.
             IF ($SelectedXMLS) {
                 #Create the scanstate syntax line for the config files.
@@ -706,10 +719,10 @@ $WallpapersXML
             # Overwrite existing save state, use volume shadow copy method, exclude all but the selected profile(s)
             # Get the selected profiles
             if ($RecentProfilesCheckBox.Checked -eq $true) {
-                $Arguments = "`"$Destination`" $ScanStateConfig /o /vsc $UsersToExclude /uel:$($RecentProfilesDaysTextBox.Text) $Uncompressed $Logs"
+                $Arguments = "`"$Destination`" $ScanStateConfig /o /vsc $UsersToExclude /uel:$($RecentProfilesDaysTextBox.Text) $EncryptionSnytax $Uncompressed $Logs"
             } else {
                 $UsersToInclude += $Script:SelectedProfile | ForEach-Object { "`"/ui:$($_.Domain)\$($_.UserName)`"" }
-                $Arguments = "`"$Destination`" $ScanStateConfig /o /vsc /ue:* $UsersToExclude $UsersToInclude $Uncompressed $Logs"
+                $Arguments = "`"$Destination`" $ScanStateConfig /o /vsc /ue:* $UsersToExclude $UsersToInclude $EncryptionSnytax $Uncompressed $Logs"
             }
 
             # Begin saving user state to new computer
@@ -795,6 +808,15 @@ $WallpapersXML
             Update-Log "No saved state found at [$Destination]. Migration cancelled." -Color 'Red'
             return
         }
+		
+            # Clear decryption syntax in case it's already defined.
+            $DecryptionSyntax = ""
+			#Determine if Encryption has been requested
+			if ($UseEncryption -eq $True){
+				#Set the syntax for the encryption
+				$DecryptionKey = """$EncryptionString"""
+				$DecryptionSnytax = "/encrypt /key:$DecryptionKey"
+			}
 
         # Generate arguments for load state process
         $Logs = "`"/l:$Destination\load.log`" `"/progress:$Destination\load_progress.log`""
@@ -829,9 +851,9 @@ $WallpapersXML
             }
 
             Update-Log "$OldUser will be migrated as $NewUser."
-            $Arguments = "`"$Destination`" `"/i:$Destination\Config.xml`" $LocalAccountOptions `"/mu:$($OldUser):$NewUser`" $Uncompressed $Logs"
+            $Arguments = "`"$Destination`" `"/i:$Destination\Config.xml`" $LocalAccountOptions `"/mu:$($OldUser):$NewUser`" $DecryptionSnytax $Uncompressed $Logs"
         } else {
-            $Arguments = "`"$Destination`" `"/i:$Destination\Config.xml`" $LocalAccountOptions $Uncompressed $Logs"
+            $Arguments = "`"$Destination`" `"/i:$Destination\Config.xml`" $LocalAccountOptions $DecryptionSnytax $Uncompressed $Logs"
         }
 
         # Begin loading user state to this computer

--- a/Invoke-USMTGUI.ps1
+++ b/Invoke-USMTGUI.ps1
@@ -20,10 +20,10 @@ begin {
     # Default configuration options - make edits starting here
 
 	# Default domain to use for profile creation
-    $Script:DefaultDomain = 'domain'
+    $Script:DefaultDomain = 'DOMAIN'
 
 	# Verify that the user running this script has this extension in their username to ensure admin rights
-    $Script:AdminExtension = 'admin'
+    $Script:AdminExtension = '-admin'
 
     # Default accounts to exclude from migration in the form of "Domain\UserName"
     $Script:DefaultExcludeProfile = @(


### PR DESCRIPTION
Corrected issues.
- /ui:* was taking precedence over exclusions when migrating all users on a system.
- /UE: syntax did not have any space in between them and was throwing errors.
- Added PSScriptRoot variable to help prevent relative path issues.

New Features
- Added functionality to use custom XML files.