### PR TITLE
added quotes to email error action

### DIFF
--- a/Invoke-USMTGUI.ps1
+++ b/Invoke-USMTGUI.ps1
@@ -1108,7 +1108,7 @@ $WallpapersXML
                     Subject     = $EmailSubject
                     Body        = $LogTextBox.Text
                     SmtpServer  = $SMTPServerTextBox.Text
-                    ErrorAction = Stop
+                    ErrorAction = 'Stop'
                 }
                 Send-MailMessage @SendMailMessageParams
             }


### PR DESCRIPTION
This is a bug fix for the email feature. Currently, when you try to run the script you will get an error saying Stop is not a valid name of a cmdlet. I just added quotes around stop.