### PR TITLE
added scripts directory and config var to hide powershell window

### DIFF
--- a/Config.ps1
+++ b/Config.ps1
@@ -73,6 +73,9 @@ $ContinueOnError = $true
 13 Enables verbose, status, and debugger output. #>
 $VerboseLevel = 13
 
+# Define wether to hide the powershell window. If you call from ISE it will always not hide
+$HidePowershellWindow = $true
+
 # Define how to handle EFS format files. Options are abort (default behaviour), skip, decryptcopy, copyraw
 $EFSHandling = "abort"
 

--- a/Invoke-USMTGUI.ps1
+++ b/Invoke-USMTGUI.ps1
@@ -2310,7 +2310,9 @@ process {
     $OldComputerScripts = Get-ChildItem -Path "$PSScriptRoot\Scripts\OldComputer" |
         Where-Object { -not $_.PSIsContainer }
     foreach ($Script in $OldComputerScripts) {
-        $OldComputerScriptsDataGridView.Rows.Add($Script)
+        if (!($Script.Contains(".gitignore"))){
+            $OldComputerScriptsDataGridView.Rows.Add($Script)
+        }
     }
 
     # Remove old computer script button
@@ -2354,7 +2356,9 @@ process {
     $NewComputerScripts = Get-ChildItem -Path "$PSScriptRoot\Scripts\NewComputer" |
         Where-Object { -not $_.PSIsContainer }
     foreach ($Script in $NewComputerScripts) {
-        $NewComputerScriptsDataGridView.Rows.Add($Script)
+        if (!($Script.Contains(".gitignore"))){
+            $NewComputerScriptsDataGridView.Rows.Add($Script)
+        }
     }
 
     # Remove new computer script button

--- a/Invoke-USMTGUI.ps1
+++ b/Invoke-USMTGUI.ps1
@@ -1176,8 +1176,8 @@ $WallpapersXML
         }
     }
 
-    # Hide parent PowerShell window unless run from ISE
-    if (-not $(Test-IsISE)) {
+    # Hide parent PowerShell window unless run from ISE or set $HidePowershellWindow to false
+    if ((-not $(Test-IsISE)) -and ($HidePowershellWindow) ) {
         $ShowWindowAsync = Add-Type -MemberDefinition @"
     [DllImport("user32.dll")]
 public static extern bool ShowWindowAsync(IntPtr hWnd, int nCmdShow);

--- a/Scripts/NewComputer/.gitignore
+++ b/Scripts/NewComputer/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/Scripts/OldComputer/.gitignore
+++ b/Scripts/OldComputer/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
fixes #36 

I also added a config variable to hide or unhide the calling PowerShell window. This makes debugging errors much easier.

Let me know your thoughts on moving the scripts directory and Config.ps1 file. Thanks for the awesome project.