### PR TITLE
Out-Null

### DIFF
--- a/Invoke-USMTGUI.ps1
+++ b/Invoke-USMTGUI.ps1
@@ -1767,7 +1767,7 @@ process {
     $ExtraDirectoriesDataGridView.RowHeadersVisible = $false
     foreach ($directory in $DefaultExtraDirectories) {
         if (Test-Path $directory) {
-            $ExtraDirectoriesDataGridView.Rows.Add($directory)
+            $ExtraDirectoriesDataGridView.Rows.Add($directory) | Out-Null
         }
         else {
             Update-Log "Extra default directory [$directory] not found. Ensure it exists before running migration." -Color 'Yellow'
@@ -2263,7 +2263,7 @@ process {
     $AddEmailRecipientButton.Font = 'Consolas, 14'
     $AddEmailRecipientButton.Add_Click({
             Update-Log "Adding to email recipients: $($EmailRecipientToAddTextBox.Text)."
-            $EmailRecipientsDataGridView.Rows.Add($EmailRecipientToAddTextBox.Text)
+            $EmailRecipientsDataGridView.Rows.Add($EmailRecipientToAddTextBox.Text) | Out-Null
         })
     $EmailRecipientsDataGridView.Controls.Add($AddEmailRecipientButton)
 


### PR DESCRIPTION
This is something that has always bothered me about the tool. As you added email addresses and extra directories you would get
```
0
1
2
0
1
```

Printed out to the console. This isn't a problem normally because you hide the PowerShell console by default. However, if you packaged the script into an exe you get a command prompt with this output.

This just adds a couple of lines to pipe the output to Null.