### PR TITLE
Add support for including and excluding specific file patterns

### DIFF
--- a/USMT/Config.ps1
+++ b/USMT/Config.ps1
@@ -26,6 +26,9 @@ $ValidIPAddress = '*'
 # Path to store the migration data on the new computer, directory will be created if it doesn't exist
 $MigrationStorePath = 'C:\TEMP\MigrationStore'
 
+# Default save remotely option
+$DefaultSaveRemotely = $true
+
 # Default user profile items to exclude from migration, more info found here:
 # https://technet.microsoft.com/en-us/library/cc722303(v=ws.10).aspx
 $DefaultIncludeAppData = $true
@@ -41,8 +44,14 @@ $DefaultIncludeMyMusic = $true
 $DefaultIncludeMyPictures = $true
 $DefaultIncludeMyVideo = $true
 
-# Default extra directories to include
+# Default extra directories to include (all file types)
 $DefaultExtraDirectories = @()
+
+# Default extra file patterns to include (global)
+$DefaultExtraFiles = @()
+
+# Default extra file patterns to exclude (global)
+$DefaultExcludeFiles = @()
 
 # Default value for SaveStateTaskCompleted on the Restore Tab
 $DefaultSaveStateTaskCompleted = $true


### PR DESCRIPTION
I had the need to include/exclude specific file patterns globally for specific file types.

My example use cases were to copy PST and SQL files that users may have stored outside of their profile. I also wanted the ability to exclude Virtual machine files.

I figured others may find this functionality useful as well. I didn't add a GUI component as I wasn't sure where to fit it in.

Thanks!