### PR TITLE
Fix incorrect var name in comments

### DIFF
--- a/USMT/Config.ps1
+++ b/USMT/Config.ps1
@@ -60,7 +60,7 @@ Example:
 This will include all PST files, anything that starts with Sample 
 and any files named Outlook.txt
 
-$DefaultExcludeFiles = @("*.pst", "Sample*", "Outlook.txt") #>
+$DefaultExtraFiles = @("*.pst", "Sample*", "Outlook.txt") #>
 $DefaultExtraFiles = @()
 
 <# Default extra file patterns to exclude (global)


### PR DESCRIPTION
Looks like I forgot to change the var name when I copied and pasted an example.

Thanks.