### PR TITLE
Admin message correction

### DIFF
--- a/Invoke-USMTGUI.ps1
+++ b/Invoke-USMTGUI.ps1
@@ -129,7 +129,7 @@ begin {
 
         if (-not $UserIdentity.IsInRole([Security.Principal.WindowsBuiltInRole] 'Administrator')) {
             Update-Log "You are not running this script as Administrator. " -Color 'Yellow' -NoNewLine
-            Update-Log "Some tasks may fail if launched as Administrator.`n" -Color 'Yellow'
+            Update-Log "Some tasks may fail if not launched as Administrator.`n" -Color 'Yellow'
         }
     }
 


### PR DESCRIPTION
https://github.com/nickrod518/Migrate-WindowsUserProfile/blob/f7fb4fc8dc20b9a9c1ec314cd4f9411d4af247eb/Invoke-USMTGUI.ps1#L132

Shouldn't say: Some tasks may fail if **not** launched as Administrator?